### PR TITLE
Add StudentHasPredicateTest skeleton

### DIFF
--- a/src/main/java/seedu/address/model/person/StudentHasPaidPredicate.java
+++ b/src/main/java/seedu/address/model/person/StudentHasPaidPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests a {@code Person}'s hasPaid status
+ */
+public class StudentHasPaidPredicate implements Predicate<Person> {
+    private final boolean hasPaid;
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET =
+            "StudentHasPaidPredicate not implemented yet";
+
+    public StudentHasPaidPredicate(boolean hasPaid) {
+        this.hasPaid = hasPaid;
+    }
+
+    //TODO Implement test
+    @Override
+    public boolean test(Person person) {
+        throw new UnsupportedOperationException(MESSAGE_NOT_IMPLEMENTED_YET);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof StudentHasPaidPredicate)) {
+            return false;
+        }
+
+        StudentHasPaidPredicate studentHasPaidPredicate = (StudentHasPaidPredicate) other;
+        return this.hasPaid == studentHasPaidPredicate.hasPaid;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("hasPaid", this.hasPaid).toString();
+    }
+}

--- a/src/test/java/seedu/address/model/person/StudentHasPaidPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/StudentHasPaidPredicateTest.java
@@ -1,0 +1,47 @@
+package seedu.address.model.person;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StudentHasPaidPredicateTest {
+    @Test
+    public void equals() {
+        StudentHasPaidPredicate predicateHasPaid = new StudentHasPaidPredicate(true);
+        StudentHasPaidPredicate predicateHasNotPaid = new StudentHasPaidPredicate(false);
+
+        // same object -> returns true
+        assertTrue(predicateHasPaid.equals(predicateHasPaid));
+        assertTrue(predicateHasNotPaid.equals(predicateHasNotPaid));
+
+        // same value -> returns true
+        StudentHasPaidPredicate predicateHasPaidCopy = new StudentHasPaidPredicate(true);
+        StudentHasPaidPredicate predicateHasNotPaidCopy = new StudentHasPaidPredicate(false);
+        assertTrue(predicateHasPaid.equals(predicateHasPaidCopy));
+        assertTrue(predicateHasNotPaid.equals(predicateHasNotPaidCopy));
+
+        // different type -> returns false
+        assertFalse(predicateHasPaid.equals(1));
+        assertFalse(predicateHasNotPaid.equals(1));
+
+        // null -> returns false
+        assertFalse(predicateHasPaid.equals(null));
+        assertFalse(predicateHasNotPaid.equals(null));
+
+        // different value -> returns false
+        assertFalse(predicateHasPaid.equals(predicateHasNotPaid));
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentHasPaidPredicate predicateHasPaid = new StudentHasPaidPredicate(true);
+        StudentHasPaidPredicate predicateHasNotPaid = new StudentHasPaidPredicate(false);
+
+        String expectedHasPaid = StudentHasPaidPredicate.class.getCanonicalName() + "{hasPaid=" + true + "}";
+        assertEquals(expectedHasPaid, predicateHasPaid.toString());
+        String expectedHasNotPaid = StudentHasPaidPredicate.class.getCanonicalName() + "{hasPaid=" + false + "}";
+        assertEquals(expectedHasNotPaid, predicateHasNotPaid.toString());
+    }
+}


### PR DESCRIPTION
AB3 does not have payment filter in Find.

Users need to be able to filter by payment to find students who have not paid.

Let's add a predicate that can check Person's payment status.

Using Predicate interface matches current Find command implementation. Also opens up possible Find command extension.